### PR TITLE
feat: Add new service for Get comics

### DIFF
--- a/backend/src/main/java/com/springboot/backend/services/serviceGetComics.java
+++ b/backend/src/main/java/com/springboot/backend/services/serviceGetComics.java
@@ -1,0 +1,10 @@
+package com.springboot.backend.services;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class serviceGetComics {
+    public String getComics() {
+        return "Comics data";
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service class to the backend that provides comic data. The main change is the addition of a simple service that returns a placeholder string for comics.

Backend service addition:

* Added a new service class `serviceGetComics` in `backend/src/main/java/com/springboot/backend/services/serviceGetComics.java` with a `getComics()` method returning a placeholder string.